### PR TITLE
Bump version to 3.3.0

### DIFF
--- a/logwrap/__init__.py
+++ b/logwrap/__init__.py
@@ -56,7 +56,7 @@ __all__ = (
     'bind_args_kwargs'
 )
 
-__version__ = '3.2.2'
+__version__ = '3.3.0'
 __author__ = "Alexey Stepanov"
 __author_email__ = 'penguinolog@gmail.com'
 __maintainers__ = {


### PR DESCRIPTION
[x] Type hints and stubs
[x] PEP0518
[x] Deprecation of `*args` for logwrap
[x] Fix empty `*args` and `**kwargs`
[x] allow override for arguments repr processing
[x] python3.7 compatibility