### PR TITLE
Mass backport from master

### DIFF
--- a/.azure_pipelines/run_tests.yml
+++ b/.azure_pipelines/run_tests.yml
@@ -1,0 +1,56 @@
+parameters:
+  name: ""
+  python: ""
+  architecture: "x64"
+  kind: "native"
+
+jobs:
+- job: ${{ format('{0}_{1}_{2}', parameters.name, parameters.architecture, parameters.kind) }}
+  dependsOn: PyLint
+  pool:
+    vmImage: "vs2017-win2016"
+
+  steps:
+  # ensure the required Python versions are available
+  - task: UsePythonVersion@0
+    displayName: setup python
+    inputs:
+      versionSpec: ${{ parameters.python }}
+      architecture: ${{ parameters.architecture }}
+
+  - script: "python -c \"import sys; print(sys.version); print(sys.executable)\""
+    displayName: show python information
+
+  - script: |
+      python -m pip install --upgrade pip
+      pip install -U setuptools
+    displayName: upgrade pip and setuptools
+
+  - script: |
+      pip install -r requirements.txt
+    displayName: Install dependencies
+
+  - ${{ if eq(parameters.kind, 'cython') }}:
+    - script: |
+        pip install -r build_requirements.txt
+      displayName: Install build requirements
+
+  - script: |
+      pip install -U wheel
+      python setup.py bdist_wheel
+      pip install --pre --no-index -f dist logwrap
+    displayName: Build and install
+
+  - script: |
+      pip install pytest pytest-sugar
+
+      pytest -vvv --junitxml=unit_result.xml test
+    displayName: PyTest
+
+  - task: PublishTestResults@2
+    displayName: publish test results via junit
+    condition: succeededOrFailed()
+    inputs:
+      testResultsFormat: "JUnit"
+      testResultsFiles: ${{ format('$(System.DefaultWorkingDirectory)/unit_result.xml') }}
+      testRunTitle: ${{ format('{0}_{1}_{2}', parameters.name, parameters.architecture, parameters.kind) }}

--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,9 @@ logwrap
 
 .. image:: https://travis-ci.org/python-useful-helpers/logwrap.svg?branch=master
     :target: https://travis-ci.org/python-useful-helpers/logwrap
+.. image:: https://dev.azure.com/python-useful-helpers/logwrap/_apis/build/status/python-useful-helpers.logwrap?branchName=master
+    :alt: Azure DevOps builds
+    :target: https://dev.azure.com/python-useful-helpers/logwrap/_build?definitionId=1
 .. image:: https://coveralls.io/repos/github/python-useful-helpers/logwrap/badge.svg?branch=master
     :target: https://coveralls.io/github/python-useful-helpers/logwrap?branch=master
 .. image:: https://readthedocs.org/projects/logwrap/badge/?version=latest
@@ -299,6 +302,8 @@ For code checking several CI systems is used in parallel:
 
 2. `coveralls: <https://coveralls.io/github/python-useful-helpers/logwrap>`_ is used for coverage display.
 
-CD system
-=========
-`Travis CI: <https://travis-ci.org/python-useful-helpers/logwrap>`_ is used for package delivery on PyPI.
+3. `Azure CI: <https://dev.azure.com/python-useful-helpers/logwrap/_build?definitionId=1>`_ is used for functional tests on Windows.
+
+CD systems
+==========
+1. `Travis CI: <https://travis-ci.org/python-useful-helpers/logwrap>`_ is used for linux and SDIST package delivery on PyPI.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,23 +1,11 @@
 environment:
-  TWINE_USERNAME: penguinolog
-  TWINE_PASSWORD:
-    secure: TCKGf77kkVeo2Pbd+lQY5Q==
-
   matrix:
-    - PYTHON: "C:\\Python35"
-      PYTHON_VERSION: "3.5.x" # currently 3.5.1
+    - PYTHON: "C:\\Python34"
+      PYTHON_VERSION: "3.4.x"
       PYTHON_ARCH: "32"
 
-    - PYTHON: "C:\\Python35-x64"
-      PYTHON_VERSION: "3.5.x" # currently 3.5.1
-      PYTHON_ARCH: "64"
-
-    - PYTHON: "C:\\Python36"
-      PYTHON_VERSION: "3.6.x" # currently 3.6.0
-      PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Python36-x64"
-      PYTHON_VERSION: "3.6.x" # currently 3.6.0
+    - PYTHON: "C:\\Python34-x64"
+      PYTHON_VERSION: "3.4.x"
       PYTHON_ARCH: "64"
 
 install:
@@ -56,6 +44,3 @@ test_script:
 artifacts:
   - path: dist\*
     name: Python built code
-
-on_success:
-  - if "%APPVEYOR_REPO_TAG%"=="true" ( pip install -U twine && twine upload dist/*.whl )

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,80 @@
+# Python package
+# Create and test a Python package on multiple Python versions.
+# Add steps that analyze code, save the dist with the build record, publish to a PyPI-compatible index, and more:
+# https://docs.microsoft.com/azure/devops/pipelines/languages/python
+
+jobs:
+- job: 'PyLint'
+  pool:
+    vmIMage: 'VS2017-Win2016'
+  strategy:
+    maxParallel: 1
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.4'
+
+  - script: |
+      python -m pip install --upgrade pip
+      pip install -U setuptools
+      pip install -r requirements.txt
+    displayName: 'Install dependencies'
+
+  - script: |
+      pip install -U pylint
+      pylint -f msvs logwrap
+    displayName: 'PyLint'
+
+- template: .azure_pipelines/run_tests.yml
+  parameters: {name: 'Python_34', python: '3.4', architecture: 'x64', kind: 'native'}
+
+#- template: .azure_pipelines/run_tests.yml
+#  parameters: {name: 'Python_34', python: '3.4', architecture: 'x64', kind: 'cython'}
+#- template: .azure_pipelines/run_tests.yml
+#  parameters: {name: 'Python_34', python: '3.4', architecture: 'x86', kind: 'cython'}
+
+
+#- job: 'Build_and_deploy'
+#  dependsOn:
+#  - Python_34_x64_native
+
+#  - Python_34_x64_cython
+#  - Python_34_x86_cython
+
+#  condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/'))
+#  pool:
+#    vmIMage: 'VS2017-Win2016'
+#  strategy:
+#    maxParallel: 6
+#    matrix:
+#      Python34_x64:
+#        python.version: '3.4'
+#      Python34_x86:
+#        python.version: '3.4'
+#        architecture: 'x86'
+
+#  steps:
+#  - task: UsePythonVersion@0
+#    inputs:
+#      versionSpec: '$(python.version)'
+#      architecture: '$(python.architecture)'
+
+#  - script: |
+#      python -m pip install --upgrade pip
+#      pip install -U setuptools
+#      pip install -r build_requirements.txt
+#    displayName: 'Install dependencies'
+
+#  - script: |
+#      python setup.py bdist_wheel
+#    displayName: 'Build'
+
+#  - task: TwineAuthenticate@0
+#    displayName: 'Twine Authenticate '
+#    inputs:
+#      externalFeeds: PyPI
+
+#  - script: |
+#      pip install -U twine
+#      twine upload -r PyPI --config-file $(PYPIRC_PATH) dist/logwrap-* --skip-existing
+#    displayName: 'Deploy'

--- a/doc/source/logwrap.rst
+++ b/doc/source/logwrap.rst
@@ -111,9 +111,10 @@ API: Decorators: `LogWrap` class and `logwrap` function.
         :rtype: typing.Union[typing.Callable, typing.Awaitable]
 
 
-.. py:class:: BoundParameter(object)
+.. py:class:: BoundParameter(inspect.Parameter)
 
     Parameter-like object store BOUND with value parameter.
+    .. versionchanged:: 4.9.5 subclass inspect.Parameter
 
     .. versionadded:: 3.3.0
 
@@ -127,65 +128,11 @@ API: Decorators: `LogWrap` class and `logwrap` function.
         :type value: typing.Any
         :raises ValueError: No default value and no value
 
-    .. py:attribute:: POSITIONAL_ONLY
-
-        ``enum.IntEnum``
-        Parameter.POSITIONAL_ONLY
-
-    .. py:attribute:: POSITIONAL_OR_KEYWORD
-
-        ``enum.IntEnum``
-        Parameter.POSITIONAL_OR_KEYWORD
-
-    .. py:attribute:: VAR_POSITIONAL
-
-        ``enum.IntEnum``
-        Parameter.VAR_POSITIONAL
-
-    .. py:attribute:: KEYWORD_ONLY
-
-        ``enum.IntEnum``
-        Parameter.KEYWORD_ONLY
-
-    .. py:attribute:: VAR_KEYWORD
-
-        ``enum.IntEnum``
-        Parameter.VAR_KEYWORD
-
-    .. py:attribute:: empty
-
-        ``typing.Type``
-        Parameter.empty
-
     .. py:attribute:: parameter
 
         Parameter object.
 
-        :rtype: inspect.Parameter
-
-    .. py:attribute:: name
-
-        Parameter name.
-
-        :rtype: typing.Union[None, str]
-
-    .. py:attribute:: default
-
-        Parameter default value.
-
-        :rtype: typing.Any
-
-    .. py:attribute:: annotation
-
-        Parameter annotation.
-
-        :rtype: typing.Union[Parameter.empty, str]
-
-    .. py:attribute:: kind
-
-        Parameter kind.
-
-        :rtype: enum.IntEnum
+        :rtype: BoundParameter
 
     .. py:attribute:: value
 
@@ -193,11 +140,11 @@ API: Decorators: `LogWrap` class and `logwrap` function.
 
         :rtype: typing.Any
 
-    .. py:method:: __hash__(self)
+    .. py:method:: __str__(self)
 
-        Block hashing.
+        String representation.
 
-        :raises TypeError: Not hashable.
+        :rtype: ``str``
 
 
 .. py:function:: bind_args_kwargs(sig, *args, **kwargs)
@@ -207,6 +154,7 @@ API: Decorators: `LogWrap` class and `logwrap` function.
     :param sig: source signature
     :type sig: inspect.Signature
     :return: Iterator for bound parameters with all information about it
-    :rtype: typing.Iterator[BoundParameter]
+    :rtype: typing.List[BoundParameter]
 
     .. versionadded:: 3.3.0
+    .. versionchanged:: 4.9.5 return list

--- a/logwrap/__init__.pxd
+++ b/logwrap/__init__.pxd
@@ -1,1 +1,9 @@
 cpdef tuple __all__
+
+cpdef str __version__
+cpdef str __author__
+cpdef str __author_email__
+cpdef dict __maintainers__
+cpdef str __url__
+cpdef str __description__
+cpdef str __license__

--- a/logwrap/__init__.pyx
+++ b/logwrap/__init__.pyx
@@ -1,7 +1,23 @@
-from .repr_utils cimport PrettyFormat, PrettyRepr, PrettyStr, pretty_repr, pretty_str
+#    Copyright 2016-2018 Alexey Stepanov aka penguinolog
+##
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
 
-from .log_wrap cimport LogWrap
-from .log_wrap import logwrap, BoundParameter, bind_args_kwargs
+import pkg_resources
+
+from logwrap.repr_utils import PrettyFormat, PrettyRepr, PrettyStr, pretty_repr, pretty_str
+
+from logwrap.log_wrap import LogWrap
+from logwrap.log_wrap import logwrap, BoundParameter, bind_args_kwargs
 
 cpdef tuple __all__ = (
     "LogWrap",
@@ -14,3 +30,27 @@ cpdef tuple __all__ = (
     "BoundParameter",
     "bind_args_kwargs",
 )
+
+cpdef str __version__
+
+try:
+    __version__ = pkg_resources.get_distribution(__name__).version
+except pkg_resources.DistributionNotFound:
+    # package is not installed, try to get from SCM
+    try:
+        import setuptools_scm  # type: ignore
+
+        __version__ = setuptools_scm.get_version()
+    except ImportError:
+        pass
+
+cpdef str __author__ = "Alexey Stepanov"
+cpdef str __author_email__ = "penguinolog@gmail.com"
+cpdef dict __maintainers__ = {
+    "Alexey Stepanov": "penguinolog@gmail.com",
+    "Antonio Esposito": "esposito.cloud@gmail.com",
+    "Dennis Dmitriev": "dis-xcom@gmail.com",
+}
+cpdef str __url__ = "https://github.com/python-useful-helpers/logwrap"
+cpdef str __description__ = "Decorator for logging function arguments and return value by human-readable way"
+cpdef str __license__ = "Apache License, Version 2.0"

--- a/logwrap/log_wrap.py
+++ b/logwrap/log_wrap.py
@@ -23,6 +23,7 @@ import logging
 import sys
 import traceback
 import typing
+import warnings
 
 import logwrap as core
 from . import class_decorator
@@ -38,21 +39,14 @@ fmt = "\n{spc:<{indent}}{{key!r}}={{val}},{{annotation}}".format(spc="", indent=
 comment = "\n{spc:<{indent}}# {{kind!s}}:".format(spc="", indent=indent).format
 
 
-class BoundParameter:
+class BoundParameter(inspect.Parameter):
     """Parameter-like object store BOUND with value parameter.
 
     .. versionadded:: 3.3.0
+    .. versionchanged:: 4.9.5 subclass inspect.Parameter
     """
 
-    __slots__ = ("_parameter", "_value")
-
-    POSITIONAL_ONLY = inspect.Parameter.POSITIONAL_ONLY
-    POSITIONAL_OR_KEYWORD = inspect.Parameter.POSITIONAL_OR_KEYWORD
-    VAR_POSITIONAL = inspect.Parameter.VAR_POSITIONAL
-    KEYWORD_ONLY = inspect.Parameter.KEYWORD_ONLY
-    VAR_KEYWORD = inspect.Parameter.VAR_KEYWORD
-
-    empty = inspect.Parameter.empty
+    __slots__ = ("_value",)
 
     def __init__(self, parameter: inspect.Parameter, value: typing.Any = inspect.Parameter.empty) -> None:
         """Parameter-like object store BOUND with value parameter.
@@ -63,7 +57,9 @@ class BoundParameter:
         :type value: typing.Any
         :raises ValueError: No default value and no value
         """
-        self._parameter = parameter
+        super(BoundParameter, self).__init__(
+            name=parameter.name, kind=parameter.kind, default=parameter.default, annotation=parameter.annotation
+        )
 
         if value is self.empty:
             if parameter.default is self.empty and parameter.kind not in (self.VAR_POSITIONAL, self.VAR_KEYWORD):
@@ -75,41 +71,13 @@ class BoundParameter:
     @property
     def parameter(self) -> inspect.Parameter:
         """Parameter object."""
-        return self._parameter
-
-    @property
-    def name(self) -> typing.Union[None, str]:
-        """Parameter name."""
-        return self.parameter.name
-
-    @property
-    def default(self) -> typing.Any:
-        """Parameter default value."""
-        return self.parameter.default
-
-    @property
-    def annotation(self) -> typing.Union[inspect.Parameter.empty, str]:
-        """Parameter annotation."""
-        return self.parameter.annotation
-
-    @property
-    def kind(self) -> int:
-        """Parameter kind."""
-        return self.parameter.kind  # type: ignore
+        warnings.warn("BoundParameter is subclass of `inspect.Parameter`", DeprecationWarning)
+        return self
 
     @property
     def value(self) -> typing.Any:
         """Parameter value."""
         return self._value
-
-    # noinspection PyTypeChecker
-    def __hash__(self) -> int:  # pragma: no cover
-        """Block hashing.
-
-        :raises TypeError: Not hashable.
-        """
-        msg = "unhashable type: '{0}'".format(self.__class__.__name__)
-        raise TypeError(msg)
 
     def __str__(self) -> str:
         """Debug purposes."""
@@ -147,9 +115,7 @@ class BoundParameter:
         return '<{} "{}">'.format(self.__class__.__name__, self)
 
 
-def bind_args_kwargs(
-    sig: inspect.Signature, *args: typing.Any, **kwargs: typing.Any
-) -> typing.Iterator[BoundParameter]:
+def bind_args_kwargs(sig: inspect.Signature, *args: typing.Any, **kwargs: typing.Any) -> typing.List[BoundParameter]:
     """Bind *args and **kwargs to signature and get Bound Parameters.
 
     :param sig: source signature
@@ -159,14 +125,16 @@ def bind_args_kwargs(
     :param kwargs: keyworded arguments
     :type kwargs: typing.Any
     :return: Iterator for bound parameters with all information about it
-    :rtype: typing.Iterator[BoundParameter]
+    :rtype: typing.List[BoundParameter]
 
     .. versionadded:: 3.3.0
+    .. versionchanged:: 4.9.5 return list
     """
+    result = []
     bound = sig.bind(*args, **kwargs).arguments
-    parameters = list(sig.parameters.values())
-    for param in parameters:
-        yield BoundParameter(parameter=param, value=bound.get(param.name, param.default))
+    for param in sig.parameters.values():
+        result.append(BoundParameter(parameter=param, value=bound.get(param.name, param.default)))
+    return result
 
 
 # pylint: disable=assigning-non-slot,abstract-method

--- a/logwrap/repr_utils.pxd
+++ b/logwrap/repr_utils.pxd
@@ -22,7 +22,29 @@ import types
 import typing
 
 
+cpdef tuple __all__
+
 cdef:
+    bint _known_callable(item: typing.Any)
+    bint _simple(item: typing.Any)
+
+    class ReprParameter:
+        cdef:
+            readonly object POSITIONAL_ONLY
+            readonly object POSITIONAL_OR_KEYWORD
+            readonly object VAR_POSITIONAL
+            readonly object KEYWORD_ONLY
+            readonly object VAR_KEYWORD
+            readonly object empty
+
+            readonly object parameter
+            readonly object name
+            readonly object annotation
+            readonly object kind
+            readonly object value
+
+    list _prepare_repr(func: typing.Union[types.FunctionType, types.MethodType])
+
     class PrettyFormat:
         cdef:
             readonly unsigned int max_indent
@@ -35,6 +57,7 @@ cdef:
             str _repr_callable(self, src: typing.Union[types.FunctionType, types.MethodType], unsigned int indent=?)
             str _repr_simple(self, src: typing.Any, unsigned int indent=?, bint no_indent_start=?)
             str _repr_iterable_item(self, bint nl, str obj_type, str prefix, unsigned int indent, str result, str suffix)
+            str _repr_iterable_items(self, src: typing.Iterable, unsigned int indent=?)
 
         cpdef str process_element(self, src: typing.Any, unsigned int indent=?, bint no_indent_start=?)
 

--- a/logwrap/repr_utils.pyx
+++ b/logwrap/repr_utils.pyx
@@ -37,106 +37,79 @@ cdef:
         return not isinstance(item, (list, set, tuple, dict, frozenset))
 
 
-class ReprParameter:
-    """Parameter wrapper wor repr and str operations over signature."""
+    class ReprParameter:
+        """Parameter wrapper wor repr and str operations over signature."""
 
-    __slots__ = ("_value", "_parameter")
+        def __cinit__(self, parameter: inspect.Parameter, value: typing.Any = inspect.Parameter.empty) -> None:
+            """Parameter-like object store BOUND with value parameter.
 
-    POSITIONAL_ONLY = inspect.Parameter.POSITIONAL_ONLY
-    POSITIONAL_OR_KEYWORD = inspect.Parameter.POSITIONAL_OR_KEYWORD
-    VAR_POSITIONAL = inspect.Parameter.VAR_POSITIONAL
-    KEYWORD_ONLY = inspect.Parameter.KEYWORD_ONLY
-    VAR_KEYWORD = inspect.Parameter.VAR_KEYWORD
+            :param parameter: parameter from signature
+            :type parameter: inspect.Parameter
+            :param value: parameter real value
+            :type value: typing.Any
+            :raises ValueError: No default value and no value
+            """
+            # Fill enum
+            self.POSITIONAL_ONLY = inspect.Parameter.POSITIONAL_ONLY
+            self.POSITIONAL_OR_KEYWORD = inspect.Parameter.POSITIONAL_OR_KEYWORD
+            self.VAR_POSITIONAL = inspect.Parameter.VAR_POSITIONAL
+            self.KEYWORD_ONLY = inspect.Parameter.KEYWORD_ONLY
+            self.VAR_KEYWORD = inspect.Parameter.VAR_KEYWORD
+            self.empty = inspect.Parameter.empty
 
-    empty = inspect.Parameter.empty
+            # Real data
+            self.parameter = parameter
+            self.kind = self.parameter.kind
 
-    def __init__(self, parameter: inspect.Parameter, value: typing.Optional[typing.Any] = None) -> None:
-        """Parameter-like object store for repr and str tasks.
+            if parameter.kind == inspect.Parameter.VAR_POSITIONAL:
+                self.name = "*" + self.parameter.name
+            elif self.kind == inspect.Parameter.VAR_KEYWORD:
+                self.name = "**" + self.parameter.name
+            else:
+                self.name = self.parameter.name
 
-        :param parameter: parameter from signature
-        :type parameter: inspect.Parameter
-        :param value: default value override
-        :type value: typing.Any
-        """
-        self._parameter = parameter
-        self._value = value if value is not None else parameter.default
+            self.annotation = self.parameter.annotation
+            self.value = value if value is not parameter.empty else parameter.default
 
-    @property
-    def parameter(self) -> inspect.Parameter:
-        """Parameter object."""
-        return self._parameter
+        # noinspection PyTypeChecker
+        def __hash__(self) -> int:
+            """Block hashing.
 
-    @property
-    def name(self) -> typing.Union[None, str]:
-        """Parameter name.
+            :raises TypeError: Not hashable.
+            """
+            cdef str msg = "unhashable type: '{0}'".format(self.__class__.__name__)
+            raise TypeError(msg)
 
-        For `*args` and `**kwargs` add prefixes
-        """
-        if self.kind == inspect.Parameter.VAR_POSITIONAL:
-            return "*" + self.parameter.name
-        if self.kind == inspect.Parameter.VAR_KEYWORD:
-            return "**" + self.parameter.name
-        return self.parameter.name
-
-    @property
-    def value(self) -> typing.Any:
-        """Parameter value to log.
-
-        If function is bound to class -> value is class instance else default value.
-        """
-        return self._value
-
-    @property
-    def annotation(self) -> typing.Union[inspect.Parameter.empty, str]:
-        """Parameter annotation."""
-        return self.parameter.annotation
-
-    @property
-    def kind(self) -> int:
-        """Parameter kind."""
-        return self.parameter.kind  # type: ignore
-
-    # noinspection PyTypeChecker
-    def __hash__(self) -> int:
-        """Block hashing.
-
-        :raises TypeError: Not hashable.
-        """
-        msg = "unhashable type: '{0}'".format(self.__class__.__name__)
-        raise TypeError(msg)
-
-    def __repr__(self) -> str:
-        """Debug purposes."""
-        return '<{} "{}">'.format(self.__class__.__name__, self)
+        def __repr__(self) -> str:
+            """Debug purposes."""
+            return '<{} "{}">'.format(self.__class__.__name__, self)
 
 
-# pylint: disable=no-member
-def _prepare_repr(func: typing.Union[types.FunctionType, types.MethodType]) -> typing.Iterator[ReprParameter]:
-    """Get arguments lists with defaults.
+    list _prepare_repr(func: typing.Union[types.FunctionType, types.MethodType]):
+        """Get arguments lists with defaults.
+    
+        :param func: Callable object to process
+        :type func: typing.Union[types.FunctionType, types.MethodType]
+        :return: repr of callable parameter from signature
+        :rtype: typing.List[ReprParameter]"""
+        cdef:
+            bint ismethod = isinstance(func, types.MethodType)
+            bint self_processed = False
+            list result = []
 
-    :param func: Callable object to process
-    :type func: typing.Union[types.FunctionType, types.MethodType]
-    :return: repr of callable parameter from signature
-    :rtype: typing.Iterator[ReprParameter]"""
-    cdef bint ismethod = isinstance(func, types.MethodType)
-    if not ismethod:
-        real_func = func
-    else:
-        real_func = func.__func__  # type: ignore
+        if not ismethod:
+            real_func = func
+        else:
+            real_func = func.__func__  # type: ignore
 
-    parameters = list(inspect.signature(real_func).parameters.values())
+        for param in inspect.signature(real_func).parameters.values():
+            if not self_processed and ismethod and func.__self__ is not None:
+                result.append(ReprParameter(param, value=func.__self__))
+                self_processed = True
+            else:
+                result.append(ReprParameter(param))
 
-    params = iter(parameters)
-    if ismethod and func.__self__ is not None:  # type: ignore
-        try:
-            yield ReprParameter(next(params), value=func.__self__)  # type: ignore
-        except StopIteration:
-            return
-    for arg in params:
-        yield ReprParameter(arg)
-
-
-# pylint: enable=no-member
+        return result
 
 
 cdef class PrettyFormat:
@@ -225,7 +198,7 @@ cdef class PrettyFormat:
         """
         raise NotImplementedError()
 
-    def _repr_iterable_items(self, src: typing.Iterable, unsigned int indent=0) -> typing.Iterator[str]:
+    cdef str _repr_iterable_items(self, src: typing.Iterable, unsigned int indent=0):
         """Repr iterable items (not designed for dicts).
 
         :param src: object to process
@@ -235,8 +208,10 @@ cdef class PrettyFormat:
         :return: repr of element in iterable item
         :rtype: typing.Iterator[str]
         """
+        cdef str result = ""
         for elem in src:
-            yield "\n" + self.process_element(src=elem, indent=self.next_indent(indent)) + ","
+            result += "\n" + self.process_element(src=elem, indent=self.next_indent(indent)) + ","
+        return result
 
     cpdef str process_element(self, src: typing.Any, unsigned int indent=0, bint no_indent_start=False):
         """Make human readable representation of object.
@@ -275,7 +250,7 @@ cdef class PrettyFormat:
                 prefix, suffix = "(", ")"
             else:
                 prefix, suffix = "{", "}"
-            result = "".join(self._repr_iterable_items(src=src, indent=indent))
+            result = self._repr_iterable_items(src=src, indent=indent)
         return self._repr_iterable_item(
             nl=no_indent_start,
             obj_type=src.__class__.__name__,
@@ -356,6 +331,7 @@ cdef class PrettyRepr(PrettyFormat):
             cdef:
                 str param_str = ""
                 str annotation
+                ReprParameter param
 
             for param in _prepare_repr(src):
                 param_str += "\n{spc:<{indent}}{param.name}".format(spc="", indent=self.next_indent(indent), param=param)
@@ -482,6 +458,7 @@ cdef class PrettyStr(PrettyFormat):
             cdef:
                 str param_str = ""
                 str annotation
+                ReprParameter param
 
             for param in _prepare_repr(src):
                 param_str += "\n{spc:<{indent}}{param.name}".format(spc="", indent=self.next_indent(indent), param=param)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,9 @@
 # Minimum requirements for the build system to execute.
 # PEP 508 specifications for PEP 518.
 requires = [
-    "setuptools > 20.2 ",
+    "setuptools >= 21.0.0,!=24.0.0,!=34.0.0,!=34.0.1,!=34.0.2,!=34.0.3,!=34.1.0,!=34.1.1,!=34.2.0,!=34.3.0,!=34.3.1,!=34.3.2,!=36.2.0",
     "wheel",
+    "setuptools_scm"
 ]
 
 [tool.black]

--- a/setup.py
+++ b/setup.py
@@ -44,29 +44,22 @@ with open("README.rst") as f:
     long_description = f.read()
 
 
-def _extension(modpath):
-    """Make setuptools.Extension."""
-    return setuptools.Extension(modpath, [modpath.replace(".", "/") + ".py"])
-
-
 requires_optimization = [
     setuptools.Extension("logwrap.class_decorator", ["logwrap/class_decorator.pyx"]),
     setuptools.Extension("logwrap.log_wrap", ["logwrap/log_wrap.pyx"]),
     setuptools.Extension("logwrap.repr_utils", ["logwrap/repr_utils.pyx"]),
+    setuptools.Extension("logwrap.__init__", ["logwrap/__init__.pyx"]),
 ]
-
-if "win32" != sys.platform:
-    requires_optimization.append(_extension("logwrap.__init__"))
 
 # noinspection PyCallingNonCallable
 ext_modules = (
     cythonize(
-        requires_optimization,
+        module_list=requires_optimization,
         compiler_directives=dict(
             always_allow_keywords=True, binding=True, embedsignature=True, overflowcheck=True, language_level=3
         ),
     )
-    if cythonize is not None
+    if cythonize is not None and "win32" != sys.platform
     else []
 )
 
@@ -90,9 +83,7 @@ class AllowFailRepair(build_ext.build_ext):
             root_dir = os.path.abspath(os.path.join(__file__, ".."))
             target_dir = build_dir if not self.inplace else root_dir
 
-            src_files = (
-                os.path.join("logwrap", "__init__.py"),
-            )
+            src_files = (os.path.join("logwrap", "__init__.py"),)
 
             for src_file in src_files:
                 src = os.path.join(root_dir, src_file)
@@ -230,7 +221,7 @@ setup_args = dict(
         "setuptools >= 21.0.0,!=24.0.0,"
         "!=34.0.0,!=34.0.1,!=34.0.2,!=34.0.3,!=34.1.0,!=34.1.1,!=34.2.0,!=34.3.0,!=34.3.1,!=34.3.2,"
         "!=36.2.0",
-        "setuptools_scm"
+        "setuptools_scm",
     ],
     use_scm_version=True,
     install_requires=required,

--- a/test/test_log_wrap_shared.py
+++ b/test/test_log_wrap_shared.py
@@ -98,7 +98,7 @@ class TestBind(unittest.TestCase):
     def test_003_no_value(self):
         params = list(log_wrap.bind_args_kwargs(sig, 1, arg3=33))
         arg_1_bound = params[0]
-        arg1_parameter = arg_1_bound.parameter
+        arg1_parameter = arg_1_bound
         with self.assertRaises(ValueError):
             log_wrap.BoundParameter(arg1_parameter, arg1_parameter.empty)
 


### PR DESCRIPTION
* Update pyproject.toml
* Extra cythonize internals
* bind_args_kwargs return list and use less memory
* Extra cythonize: _repr_iterable_items
* BoundParameter: subclass inspect.Parameter
* Set up CI with Azure Pipelines (#65)
* Update README.rst
* Fix azure CI status badge
* Moved from private
* Azure pipelines: build x64 and x86, use template (#68)
* Pylint is precondition on Azure side

* fix hidden errors: some cython code replaced by correct python
* unify API
* temporary: do not cythonize on windows: looks like cython bug